### PR TITLE
cisco_sb_fan check is not comptible with Checkmk 2.0

### DIFF
--- a/cisco_sb_fans/src/checks/cisco_sb_fan
+++ b/cisco_sb_fans/src/checks/cisco_sb_fan
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- encoding: utf-8; py-indent-offset: 4 -*-
 
 # (c) Robert Oschwald 2019             
@@ -31,6 +31,12 @@
 # to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 # Boston, MA 02110-1301 USA.
 
+# NOTE: Careful when replacing the *-import below with a more specific import. This can cause
+# problems because it might remove variables from the check-context which are necessary for
+# resolving legacy discovery results such as [("SUMMARY", "diskstat_default_levels")]. Furthermore,
+# it might also remove variables needed for accessing discovery rulesets.
+from cmk.base.check_legacy_includes.cisco_sensor_item import *  # pylint: disable=wildcard-import,unused-wildcard-import
+
 cisco_fan_states = ('', 'normal', 'warning', 'critical',
                     'shutdown', 'notPresent', 'notFunctioning')
 
@@ -59,5 +65,4 @@ check_info["cisco_sb_fan"] = {
         lambda oid: "switch" in oid(".1.3.6.1.2.1.1.1.0").lower() \
                      and oid(".1.3.6.1.4.1.9.6.1.101.53.14.1.10.1") is not None \
                      and "cisco" in oid(".1.3.6.1.4.1.9.6.1.101.53.14.1.10.1").lower(),
-    "includes":     ['cisco_sensor_item.include'],
 }

--- a/cisco_sb_fans/src/info
+++ b/cisco_sb_fans/src/info
@@ -6,6 +6,6 @@
  'name': 'cisco_sb_fans',
  'num_files': 2,
  'title': u'Check FAN health status on Cisco SB switches',
- 'version': '1.0.1',
- 'version.min_required': '1.2.8',
- 'version.packaged': '1.5.0p15'}
+ 'version': '1.0.2',
+ 'version.min_required': '2.0.0',
+ 'version.packaged': '2.0.0b7'}

--- a/cisco_sb_fans/src/info
+++ b/cisco_sb_fans/src/info
@@ -6,6 +6,6 @@
  'name': 'cisco_sb_fans',
  'num_files': 2,
  'title': u'Check FAN health status on Cisco SB switches',
- 'version': '1.0.2',
+ 'version': '2.0.0',
  'version.min_required': '2.0.0',
  'version.packaged': '2.0.0b7'}


### PR DESCRIPTION
Unfortunatally the check cisco_sb_fan isn't compatible with Checkmk 2.0 because the include of cisco_sensor_item.include doesn't work anymore.

I changed the include, but unfortunatelly so the check becomes incompatible with pre 2.0 versions.