### PR TITLE
make check compatible with Checkmk 2.2.x

### DIFF
--- a/cisco_sb_fans/src/checks/cisco_sb_fan
+++ b/cisco_sb_fans/src/checks/cisco_sb_fan
@@ -41,7 +41,7 @@
 
 from cmk.base.check_api import OID_END
 from cmk.base.plugins.agent_based.agent_based_api.v1 import contains, exists, matches
-from cmk.base.check_legacy_includes.cisco_sensor_item import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from cmk.base.plugins.agent_based.utils.cisco_sensor_item import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 # Cisco SB Switches do not identify as "cisco" as the other Cisco Switches do on oid .1.3.6.1.2.1.1.1.0
 # We need to check 3 values to ensure a Cisco SB Switch:

--- a/cisco_sb_fans/src/info
+++ b/cisco_sb_fans/src/info
@@ -1,10 +1,10 @@
 {'author': 'Robert Oschwald <robertoschwald@gmail.com>',
- 'description': u'This check monitors the state of fans on Cisco SB switches.',
+ 'description': 'This check monitors the state of fans on Cisco SB switches.\n',
  'download_url': 'https://github.com/robertoschwald/check_mk_plugins/blob/master/cisco_sb_fans',
- 'files': {'checkman': ['cisco_sb_fan'],
-           'checks': ['cisco_sb_fan']},
+ 'files': {'checkman': ['cisco_sb_fan'], 'checks': ['cisco_sb_fan']},
  'name': 'cisco_sb_fans',
- 'title': u'Check FAN health status on Cisco SB switches',
- 'version': '2.0.1',
- 'version.min_required': '2.0.0',
- 'version.packaged': '2.0.0p20'}
+ 'title': 'Check FAN health status on Cisco SB switches',
+ 'version': '2.2.0',
+ 'version.min_required': '2.2.0',
+ 'version.packaged': '2.2.0p23',
+ 'version.usable_until': None}


### PR DESCRIPTION
Hallo Robert,

jetzt nochmal gegen deinen cmk2.0.0 branch.
Der check ist allerdings tatsächlich erst mit cmk2.2.0 einsetzbar (vorher liegen die includes noch an der alten Stelle)

Beste Grüße
   Daniel